### PR TITLE
Fix ZygorMinimapIcon display

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -13,7 +13,7 @@ local WHITE_LIST = {
 	'MiniMapBattlefieldFrame','MiniMapTrackingButton','MiniMapMailFrame','HelpOpenTicketButton',
 	'GatherMatePin','HandyNotesPin','TimeManagerClockButton','Archy','GatherNote','MinimMap',
 	'Spy_MapNoteList_mini','ZGVMarker','poiWorldMapPOIFrame','WorldMapPOIFrame','QuestMapPOI',
-	'GameTimeFrame'
+	'GameTimeFrame','ZygorGuidesViewerMapIcon'
 }
 local BUTTON_POINTS = {}
 


### PR DESCRIPTION
Right now Zygor Minimap Icon is kinda scuffed

![wow_fvc91469jX](https://user-images.githubusercontent.com/74269253/230503852-c960f958-07f8-4e1a-8d97-3b730e22bed1.png)

With this push it's gonna be bigger than other minimap buttons, but will look much better.